### PR TITLE
Fix return type for `serves` method example

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -158,7 +158,7 @@ For example, let's pretend we are writing a `WordPressValetDriver`. Our serve me
      * @param  string  $sitePath
      * @param  string  $siteName
      * @param  string  $uri
-     * @return void
+     * @return bool
      */
     public function serves($sitePath, $siteName, $uri)
     {


### PR DESCRIPTION
Not that it's a big deal in the grand scheme of things but I notice the return type in the example for the `serves` method was `void` but doesn't the `is_dir` method return a boolean (ie. true or false), so the return type should be `bool`?